### PR TITLE
Support Docker secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
         uses: ./action
         with:
           compose-file: action/docker-compose.test.yml
+          secrets: |
+            - name: secret
+              value: ${{ secrets.SECRET }}
           stack-name: david
           ssh-user-at-host: david@127.0.0.1
           ssh-port: 2222

--- a/README.md
+++ b/README.md
@@ -37,16 +37,20 @@ jobs:
           compose-file: docker-compose.yml
           stack-name: my-app
           ssh-user-at-host: deployer@123.124.125.126
+          secrets: |
+            - name: secret
+              value: ${{ secrets.SECRET }}
 ```
 
 ## Inputs
 
-| Name               | Description                                                    |
-|--------------------|----------------------------------------------------------------|
-| `compose-file`     | Path to your docker compose definition inside the repository.  |
-| `stack-name`       | Name of the Docker Stack that shoud be created on your server. |
-| `ssh-user-at-host` | User@host to connect to (e.g. `hello@myhost.com`)              |
-| `ssh-port`         | SSH port to connect to. Defaults to 22 if not defined.         |
+| Name               | Description                                                                                                                                                                                         |
+|--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `compose-file`     | Path to your docker compose definition inside the repository.                                                                                                                                       |
+| `secrets`          | Allows to define a YAML array of Docker secrets which should be created (not required). You need to define it as a multiline YAML string, as this is technically not supported by Actions directly. |
+| `stack-name`       | Name of the Docker Stack that shoud be created on your server.                                                                                                                                      |
+| `ssh-user-at-host` | User@host to connect to (e.g. `hello@myhost.com`)                                                                                                                                                   |
+| `ssh-port`         | SSH port to connect to. Defaults to 22 if not defined.                                                                                                                                              |
 
 ## License
 

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: 'Path to the docker-compose file'
     required: true
 
+  secrets:
+    description: "Docker secrets to create during the stack"
+    required: false
+
   stack-name:
     description: 'Name of the stack to deploy'
     required: true
@@ -20,7 +24,7 @@ inputs:
   ssh-user-at-host:
     description: 'User@host to connect to'
     required: true
-  
+
   ssh-port:
     description: "Port to connect to with SSH"
     required: false
@@ -42,6 +46,18 @@ runs:
     - name: Initialising Swarm if required
       run: docker node ls || docker swarm init
       shell: bash
+
+    - name: Create secrets
+      run: |
+        echo "${{ inputs.secrets }}" | yq e '.[]' - | while IFS= read -r line; do
+          secret_name=$(echo "$line" | yq e '.name' -)
+          secret_value=$(echo "$line" | yq e '.value' -)
+
+          # Execute the Docker secret command
+          docker secret inspect "$secret_name" > /dev/null 2>&1 || echo "$secret_value" | docker secret create "$secret_name" -
+        done
+      shell: bash
+      if: "${{ inputs.secrets != '' }}"
 
     - name: Pull docker-stack-wait image
       run: docker pull sudobmitch/docker-stack-wait:v0.2.5

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -4,5 +4,11 @@ services:
   web:
     image: "hashicorp/http-echo"
     command: ["-listen", ":8080", "-text", "Hello World"]
+    secrets:
+      - secret
     ports:
       - 8080:8080
+
+secrets:
+  secret:
+    external: true


### PR DESCRIPTION
Closes #3

This PR adds support for creating Docker secrets using the action. A user can pass a YAML array to the Action, and using `yq`, we create each of the specified secrets.

Please note that GitHub Actions only supports strings as an input for an action. Therefore, secrets also need to be passed as a multiline string.