### PR TITLE
Support GitHub deployments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
 
+    permissions:
+      deployments: write
+
     steps:
       # cloning into "root" does not work when trying to call the action from itself
       # inspired by Microsoft: https://github.com/microsoft/action-python/blob/c8ec939994d7ed2ec77b7bbe59ed5f5b72fb5607/.github/workflows/test.yml#L21
@@ -38,6 +41,8 @@ jobs:
         uses: ./action
         with:
           compose-file: action/docker-compose.test.yml
+          environment: "test"
+          environment-url: "https://www.simplificator.com"
           secrets: |
             - name: secret
               value: ${{ secrets.SECRET }}

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ on:
 jobs:
   deploy:
     runs-on: "ubuntu-latest"
+    permissions:
+      deployments: write
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -35,6 +38,8 @@ jobs:
         uses: simplificator/deploy-action@main
         with:
           compose-file: docker-compose.yml
+          environment: production
+          environment-url: https://example.com
           stack-name: my-app
           ssh-user-at-host: deployer@123.124.125.126
           secrets: |
@@ -44,13 +49,15 @@ jobs:
 
 ## Inputs
 
-| Name               | Description                                                                                                                                                                                         |
-|--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `compose-file`     | Path to your docker compose definition inside the repository.                                                                                                                                       |
-| `secrets`          | Allows to define a YAML array of Docker secrets which should be created (not required). You need to define it as a multiline YAML string, as this is technically not supported by Actions directly. |
-| `stack-name`       | Name of the Docker Stack that shoud be created on your server.                                                                                                                                      |
-| `ssh-user-at-host` | User@host to connect to (e.g. `hello@myhost.com`)                                                                                                                                                   |
-| `ssh-port`         | SSH port to connect to. Defaults to 22 if not defined.                                                                                                                                              |
+| Name               | Description                                                                                                                                                                                     |
+|--------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `compose-file`     | Path to your docker compose definition inside the repository.                                                                                                                                   |
+| `environment`      | The name of the environment for the deployment (optional). Used to create a GitHub deployment.                                                                                                  |
+| `environment-url`  | A URL to access your deployment (optional). Used to create a GitHub deployment.                                                                                                                 |
+| `secrets`          | Allows to define a YAML array of Docker secrets which should be created (optional). You need to define it as a multiline YAML string, as this is technically not supported by Actions directly. |
+| `stack-name`       | Name of the Docker Stack that shoud be created on your server.                                                                                                                                  |
+| `ssh-user-at-host` | User@host to connect to (e.g. `hello@myhost.com`)                                                                                                                                               |
+| `ssh-port`         | SSH port to connect to. Defaults to 22 if not defined.                                                                                                                                          |
 
 ## License
 

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,14 @@ inputs:
     description: 'Path to the docker-compose file'
     required: true
 
+  environment:
+    description: "The name of the environment for the deployment"
+    required: false
+
+  environment-url:
+    description: "A URL to access your deployment"
+    required: false
+
   secrets:
     description: "Docker secrets to create during the stack"
     required: false
@@ -33,6 +41,16 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - uses: chrnorm/deployment-action@v2
+      name: Create GitHub deployment
+      id: deployment
+      with:
+        token: "${{ github.token }}"
+        environment-url: "${{ inputs.environment-url }}"
+        environment: "${{ inputs.environment }}"
+        initial-status: "in_progress"
+      if: "${{ inputs.environment != '' && inputs.environment-url != '' }}"
+
     - name: Check if system is available through SSH
       run: "ssh -o ConnectTimeout=5 -p ${{ inputs.ssh-port }} ${{ inputs.ssh-user-at-host }} exit"
       shell: bash
@@ -76,3 +94,21 @@ runs:
         docker system prune -af
         docker context remove --force target
       shell: bash
+
+    - name: Update deployment status (success)
+      uses: chrnorm/deployment-status@v2
+      with:
+        token: "${{ github.token }}"
+        environment-url: "${{ steps.deployment.outputs.environment_url }}"
+        deployment-id: "${{ steps.deployment.outputs.deployment_id }}"
+        state: "success"
+      if: "${{ inputs.environment != '' && inputs.environment-url != '' && success() }}"
+
+    - name: Update deployment status (failed)
+      uses: chrnorm/deployment-status@v2
+      with:
+        token: "${{ github.token }}"
+        environment-url: "${{ steps.deployment.outputs.environment_url }}"
+        deployment-id: "${{ steps.deployment.outputs.deployment_id }}"
+        state: "failure"
+      if: "${{ inputs.environment != '' && inputs.environment-url != '' && failure() }}"


### PR DESCRIPTION
This PR adds two new inputs which allow to create a GitHub deployment when running the action. We wrap another action to do so. These inputs are optional, no deployment will be created if not set.