### PR TITLE
Release v1.0.1: Remove obsolete docker-stack-wait shell script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,9 @@ jobs:
           mkdir -p ~/.ssh
           ssh-keyscan -t rsa -p 2222 127.0.0.1 >> ~/.ssh/known_hosts
 
-      - name: Run a container to verify that docker system prune will work
+      - name: Pull an image to verify that docker system prune will work
         run: |
-          ssh -p 2222 david@127.0.0.1 docker run --name debian debian:12
+          ssh -p 2222 david@127.0.0.1 docker pull debian:12
         shell: bash
 
       - name: Test
@@ -63,14 +63,6 @@ jobs:
               exit 0
           else
               echo "Pattern not matched."
-              exit 1
-          fi
-        shell: bash
-
-      - name: Check that the Debian container got removed
-        run: |
-          if ssh -p 2222 david@127.0.0.1 docker container inspect debian; then
-              echo "Debian container was not cleaned up!"
               exit 1
           fi
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,11 +67,6 @@ jobs:
           fi
         shell: bash
 
-      - name: Check that docker-stack-wait image is still there
-        run: |
-          ssh -p 2222 david@127.0.0.1 docker image inspect sudobmitch/docker-stack-wait:v0.2.5
-        shell: bash
-
       - name: Check that the Debian container got removed
         run: |
           if ssh -p 2222 david@127.0.0.1 docker container inspect debian; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2024-11-24
+
+### Changed
+
+- Removed deprecated docker-stack-wait shell script
+- Simplified Docker system prune command
+
 ## [1.0.0] - 2024-05-13
 
 Initial release.

--- a/action.yml
+++ b/action.yml
@@ -1,16 +1,16 @@
-name: 'Deploy'
-description: 'Deploy an application using Docker Swarm'
-author: 'Simplificator AG'
+name: "Deploy"
+description: "Deploy an application using Docker Swarm"
+author: "Simplificator AG"
 
 # Add your action's branding here. This will appear on the GitHub Marketplace.
 branding:
-  icon: 'activity'
-  color: 'black'
+  icon: "activity"
+  color: "black"
 
 # Define your inputs here.
 inputs:
   compose-file:
-    description: 'Path to the docker-compose file'
+    description: "Path to the docker-compose file"
     required: true
 
   environment:
@@ -26,11 +26,11 @@ inputs:
     required: false
 
   stack-name:
-    description: 'Name of the stack to deploy'
+    description: "Name of the stack to deploy"
     required: true
 
   ssh-user-at-host:
-    description: 'User@host to connect to'
+    description: "User@host to connect to"
     required: true
 
   ssh-port:
@@ -77,21 +77,13 @@ runs:
       shell: bash
       if: "${{ inputs.secrets != '' }}"
 
-    - name: Pull docker-stack-wait image
-      run: docker pull sudobmitch/docker-stack-wait:v0.2.5
-      shell: bash
-
     - name: Deploying stack
-      run: docker stack deploy --compose-file ${{ inputs.compose-file }} --prune --with-registry-auth ${{ inputs.stack-name }}
-      shell: bash
-
-    - name: Waiting for deployment to complete
-      run: docker run --rm -i -v $(pwd)/${{ inputs.compose-file }}:/docker-compose.yml -v /var/run/docker.sock:/var/run/docker.sock sudobmitch/docker-stack-wait:v0.2.5 -l "--since 2m" -t 120 ${{ inputs.stack-name }}
+      run: docker stack deploy --detach=false --compose-file ${{ inputs.compose-file }} --prune --with-registry-auth ${{ inputs.stack-name }}
       shell: bash
 
     - name: Cleaning up
       run: |
-        docker system prune -af --filter 'label!=org.opencontainers.image.source=git://github.com/sudo-bmitch/docker-stack-wait.git' --filter 'label!=org.opencontainers.image.version=v0.2.5'
+        docker system prune -af
         docker context remove --force target
       shell: bash
 

--- a/docker/server.Dockerfile
+++ b/docker/server.Dockerfile
@@ -1,20 +1,19 @@
-FROM geerlingguy/docker-debian12-ansible
+FROM docker:dind
 
-RUN apt update && \
-  apt install -y ca-certificates curl gnupg openssh-server && \
-  install -m 0755 -d /etc/apt/keyrings && \
-  curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
-  chmod a+r /etc/apt/keyrings/docker.gpg && \
-  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
-  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null && \
-  apt update && \
-  apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+# Install OpenSSH and other needed packages
+RUN apk add --no-cache openssh sudo
 
-RUN echo "PermitEmptyPasswords yes \n \
-PermitRootLogin yes \n \
-PasswordAuthentication yes" > /etc/ssh/sshd_config
+# Configure SSH
+RUN ssh-keygen -A && \
+    echo "PermitEmptyPasswords yes" >> /etc/ssh/sshd_config && \
+    echo "PermitRootLogin yes" >> /etc/ssh/sshd_config && \
+    echo "PasswordAuthentication yes" >> /etc/ssh/sshd_config
 
-RUN adduser david && \
-  usermod -aG docker david && \
-  echo "david ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/david && \
-  passwd -d david
+# Create user david
+RUN adduser -D david && \
+    addgroup david docker && \
+    echo "david ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/david && \
+    passwd -d david
+
+# Start both dockerd and sshd
+CMD dockerd-entrypoint.sh & /usr/sbin/sshd -D


### PR DESCRIPTION
## Changes
- Removed obsolete docker-stack-wait shell script in favor of native --detach flag
- Simplified Docker system prune command
- Updated CHANGELOG.md for v1.0.1 release

## Release Notes
This is a maintenance release that removes filters for docker-stack-wait which has beed deprecated (see https://github.com/sudo-bmitch/docker-stack-wait).